### PR TITLE
Add art show import page and mass email

### DIFF
--- a/anthrocon/__init__.py
+++ b/anthrocon/__init__.py
@@ -1,20 +1,12 @@
 from os.path import join
-from pathlib import Path
 
-from uber.config import c, parse_config
 from uber.jinja import template_overrides
 from uber.utils import mount_site_sections, static_overrides
-
-from anthrocon._version import __version__  # noqa: F401
-
-
-config = parse_config("anthrocon", Path(__file__).parents[0])
-c.include_plugin_config(config)
-mount_site_sections(config['module_root'])
-static_overrides(join(config['module_root'], 'static'))
-template_overrides(join(config['module_root'], 'templates'))
-
-
-# These need to come last so they can make use of config properties
+from .config import config
 from anthrocon.automated_emails import *  # noqa: F401,E402,F403
 from anthrocon.models import *  # noqa: F401,E402,F403
+
+
+static_overrides(join(config['module_root'], 'static'))
+template_overrides(join(config['module_root'], 'templates'))
+mount_site_sections(config['module_root'])

--- a/anthrocon/__init__.py
+++ b/anthrocon/__init__.py
@@ -1,12 +1,16 @@
+from datetime import datetime
+
 from os.path import join
 
 from uber.jinja import template_overrides
 from uber.utils import mount_site_sections, static_overrides
+
+from anthrocon._version import __version__  # noqa: F401
 from .config import config
-from anthrocon.automated_emails import *  # noqa: F401,E402,F403
-from anthrocon.models import *  # noqa: F401,E402,F403
 
+from . import models  # noqa: F401,E402,F403
+from . import automated_emails  # noqa: F401
 
+mount_site_sections(config['module_root'])
 static_overrides(join(config['module_root'], 'static'))
 template_overrides(join(config['module_root'], 'templates'))
-mount_site_sections(config['module_root'])

--- a/anthrocon/automated_emails.py
+++ b/anthrocon/automated_emails.py
@@ -1,13 +1,12 @@
 from datetime import timedelta
 
-from uber.automated_emails import AutomatedEmailFixture, MarketplaceEmailFixture, StopsEmailFixture
+from uber.automated_emails import AutomatedEmailFixture, ArtShowAppEmailFixture, StopsEmailFixture
 from uber.config import c
 from uber.models import Attendee, AutomatedEmail
 from uber.utils import before, days_before, days_after
 
-# ArtShowAppEmailFixture(
-#     Attendee,
-#     '{EVENT_NAME} hospitality suite information',
-#     'guest_food_info.txt',
-#     lambda a: a.badge_type == c.GUEST_BADGE,
-#     ident='anthrocon_guest_food_info')
+ArtShowAppEmailFixture(
+    'Your {EVENT_NAME} Art Show Reservation',
+    'art_show/import.html',
+    lambda a: a.created <= c.ART_SHOW_REG_START,
+    ident='art_show_import')

--- a/anthrocon/config.py
+++ b/anthrocon/config.py
@@ -1,0 +1,17 @@
+from os.path import join
+from pathlib import Path
+
+from uber.config import c, Config, dynamic, parse_config, request_cached_property
+from uber.menu import MenuItem
+from uber.models import Attendee, Session
+
+from ._version import __version__  # noqa: F401
+
+config = parse_config("anthrocon", Path(__file__).parents[0])
+c.include_plugin_config(config)
+
+c.MENU.append_menu_item(
+    MenuItem(name='Anthrocon', submenu=[
+        MenuItem(name='Art Show Import', href='../anthrocon/art_show_import'),
+    ])
+)

--- a/anthrocon/site_sections/anthrocon.py
+++ b/anthrocon/site_sections/anthrocon.py
@@ -80,7 +80,7 @@ class Root:
                 )
                 model_instances['attendee'] = Attendee()
                 model_instances['attendee'].placeholder = True
-                model_instances['attendee'].badge_status == c.NOT_ATTENDING
+                model_instances['attendee'].badge_status = c.NOT_ATTENDING
 
             model_instances['app'].attendee = model_instances['attendee']
             model_instances['app'].last_synced['art_show_import'] = datetime.now(UTC).isoformat()

--- a/anthrocon/site_sections/anthrocon.py
+++ b/anthrocon/site_sections/anthrocon.py
@@ -15,22 +15,25 @@ from collections import defaultdict
 from datetime import datetime
 
 from sqlalchemy.dialects.postgresql.json import JSONB
+from sqlalchemy.exc import IntegrityError, NoResultFound
 from pockets.autolog import log
 from pytz import UTC
 from sqlalchemy.types import Date, Boolean, Integer
 from sqlalchemy import text
 
 from uber.badge_funcs import badge_consistency_check
+from uber.config import c
 from uber.decorators import all_renderable, csv_file, public, site_mappable
 from uber.models import Attendee, ArtShowApplication, Session, UTCDateTime
 from uber.tasks.health import ping
 
 
+@all_renderable()
 class Root:
-    def art_show_import(self, message='', all_instances=None):
+    def art_show_import(self, message='', all_instances=[]):
         return {
             'message': message,
-            'attendees': all_instances
+            'models_imported': [x for xs in all_instances for x in xs]
         }
 
     def import_art_show_models(self, session, model_import):
@@ -48,43 +51,86 @@ class Root:
         id_lists = defaultdict(list)
 
         for row in result:
+            import_ids = {}
             model_instances = {}
             colnames = {}
 
             for key in model_dict.keys():
                 if key + '_import_id' in row:
-                    import_id = row.pop(key + '_import_id')
+                    import_ids[key] = row.pop(key + '_import_id')
                     try:
-                        model_instances[key] = getattr(session, model_dict[key])(import_id, allow_invalid=True)
-                    except Exception:
+                        model_instances[key] = session.query(model_dict[key]).filter(
+                            model_dict[key].external_id == {'art_show_import': import_ids[key]}).one()
+                    except NoResultFound:
+                        pass
+                    except Exception as e:
+                        log.error(str(e))
                         session.rollback()
+                        return self.art_show_import(str(e))
             
             if model_instances.get('app'):
                 model_instances['attendee'] = model_instances['app'].attendee
             elif model_instances.get('attendee'):
-                model_instances['app'] = ArtShowApplication()
-                model_instances['app'].attendee = model_instances['attendee']
+                model_instances['app'] = ArtShowApplication(
+                    external_id = {'art_show_import': import_ids['app']}
+                )
             else:
-                model_instances['app'] = ArtShowApplication()
+                model_instances['app'] = ArtShowApplication(
+                    external_id = {'art_show_import': import_ids['app']}
+                )
                 model_instances['attendee'] = Attendee()
+                model_instances['attendee'].placeholder = True
+                model_instances['attendee'].badge_status == c.NOT_ATTENDING
+
+            model_instances['app'].attendee = model_instances['attendee']
+            model_instances['app'].last_synced['art_show_import'] = datetime.now(UTC).isoformat()
+            model_instances['attendee'].last_synced['art_show_import'] = datetime.now(UTC).isoformat()
+
+            # Swap the preferred and first names where appropriate
+            orig_first_name = row.pop('attendee_first_name', None)
+            orig_last_name = row.pop('attendee_last_name', None)
+            orig_preferred_name = row.pop('attendee_preferred_name', None)
+
+            if orig_preferred_name:
+                preferred_name_split = orig_preferred_name.rsplit(' ', 1)
+                if len(preferred_name_split) > 1:
+                    preferred_last_name = preferred_name_split[1]
+                    model_instances['attendee'].first_name = preferred_name_split[0]
+                    if preferred_last_name == orig_last_name:
+                        model_instances['attendee'].last_name = orig_last_name
+                        model_instances['attendee'].legal_name = orig_first_name
+                    else:
+                        model_instances['attendee'].last_name = preferred_name_split[1]
+                        model_instances['attendee'].legal_name = orig_first_name + " " + orig_last_name
+                else:
+                    model_instances['attendee'].legal_name = orig_first_name
+                    model_instances['attendee'].last_name = orig_last_name
+                    model_instances['attendee'].first_name = orig_preferred_name
+            else:
+                model_instances['attendee'].first_name = orig_first_name
+                model_instances['attendee'].last_name = orig_last_name
 
             for key in model_dict.keys():
-                colnames[key] = [key for key in row.keys() if key.startswith(key)]
+                session.add(model_instances[key])
+                colnames[key] = [k for k in row.keys() if k.startswith(key)]
 
             for key in model_dict.keys():
                 for colname in colnames[key]:
                     col = col_dict[key][colname.removeprefix(key + "_")]
-                    setattr(model_instances[key], col, model_instances[key].coerce_column_data(col, row[colname]))
+                    if row[colname]:
+                        setattr(model_instances[key], colname.removeprefix(key + "_"), model_instances[key].coerce_column_data(col, row[colname]))
 
             for key in model_dict.keys():
                 id_lists[key].append(model_instances[key].id)
+            
+            log.error(model_instances['app'].external_id)
 
         try:
             session.commit()
-        except Exception:
+        except Exception as e:
             log.error('ImportError', exc_info=True)
             session.rollback()
-            message = 'Import unsuccessful'
+            message = str(e)
 
         all_instances = []
         if len(id_lists) > 0:

--- a/anthrocon/site_sections/anthrocon.py
+++ b/anthrocon/site_sections/anthrocon.py
@@ -1,0 +1,94 @@
+import os
+import json
+import shlex
+import time
+import sys
+import subprocess
+import traceback
+import csv
+import random
+import six
+import pypsutil
+import cherrypy
+import threading
+from collections import defaultdict
+from datetime import datetime
+
+from sqlalchemy.dialects.postgresql.json import JSONB
+from pockets.autolog import log
+from pytz import UTC
+from sqlalchemy.types import Date, Boolean, Integer
+from sqlalchemy import text
+
+from uber.badge_funcs import badge_consistency_check
+from uber.decorators import all_renderable, csv_file, public, site_mappable
+from uber.models import Attendee, ArtShowApplication, Session, UTCDateTime
+from uber.tasks.health import ping
+
+
+class Root:
+    def art_show_import(self, message='', all_instances=None):
+        return {
+            'message': message,
+            'attendees': all_instances
+        }
+
+    def import_art_show_models(self, session, model_import):
+        model_dict = {
+            'attendee': Attendee,
+            'app': ArtShowApplication,
+        }
+        col_dict = {}
+
+        for key, model in model_dict.items():
+            col_dict[key] = {col.name: getattr(model, col.name) for col in model.__table__.columns}
+        message = ''
+
+        result = csv.DictReader(model_import.file.read().decode('utf-8').split('\n'))
+        id_lists = defaultdict(list)
+
+        for row in result:
+            model_instances = {}
+            colnames = {}
+
+            for key in model_dict.keys():
+                if key + '_import_id' in row:
+                    import_id = row.pop(key + '_import_id')
+                    try:
+                        model_instances[key] = getattr(session, model_dict[key])(import_id, allow_invalid=True)
+                    except Exception:
+                        session.rollback()
+            
+            if model_instances.get('app'):
+                model_instances['attendee'] = model_instances['app'].attendee
+            elif model_instances.get('attendee'):
+                model_instances['app'] = ArtShowApplication()
+                model_instances['app'].attendee = model_instances['attendee']
+            else:
+                model_instances['app'] = ArtShowApplication()
+                model_instances['attendee'] = Attendee()
+
+            for key in model_dict.keys():
+                colnames[key] = [key for key in row.keys() if key.startswith(key)]
+
+            for key in model_dict.keys():
+                for colname in colnames[key]:
+                    col = col_dict[key][colname.removeprefix(key + "_")]
+                    setattr(model_instances[key], col, model_instances[key].coerce_column_data(col, row[colname]))
+
+            for key in model_dict.keys():
+                id_lists[key].append(model_instances[key].id)
+
+        try:
+            session.commit()
+        except Exception:
+            log.error('ImportError', exc_info=True)
+            session.rollback()
+            message = 'Import unsuccessful'
+
+        all_instances = []
+        if len(id_lists) > 0:
+            for key, model in model_dict.items():
+                all_instances.append(session.query(model).filter(model.id.in_(id_lists[key])).all())
+
+        return self.art_show_import(message, all_instances)

--- a/anthrocon/templates/anthrocon/art_show_import.html
+++ b/anthrocon/templates/anthrocon/art_show_import.html
@@ -5,28 +5,24 @@
 <h2> CSV Table Imports </h2>
 This attempts to import a csv file for the art show. <strong>Please do not refresh this page. THIS PAGE IS FOR EXPERTS ONLY.</strong>
 
-<form action="import_model" method="post" enctype="multipart/form-data">
+<form action="import_art_show_models" method="post" enctype="multipart/form-data">
     <input type="file" name="model_import" /><br />
     <input type="submit" value="Upload" />
 </form>
 <br/>
-{% if attendees %}
+{% if models_imported %}
         <div class="control-group"><h4>Imported Data</h4></div>
     <table class="table table-striped datatable">
     <thead><tr>
         <th>ID</th>
         <th>Name</th>
-        <th>Type</th>
-        <th>When</th>
     </tr></thead>
-{% for attendee in attendees %}
+{% for model in models_imported %}
     <tr>
         <td id="uuid">
-            {{ attendee.id }}
+            {{ model.id }}
         </td>
-        <td id="name">{{ attendee|form_link }}</td>
-        <td id="type">{{ attendee.type }} {{ attendee.badge_type_label }}</td>
-        <td id="when">{{ attendee.when }} {{ attendee.registered }}</td>
+        <td id="name">{{ model|form_link }}</td>
     </tr>
 {% endfor %}
 </table>

--- a/anthrocon/templates/anthrocon/art_show_import.html
+++ b/anthrocon/templates/anthrocon/art_show_import.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}CSV Import{% endblock %}
+{% block content %}
+
+<h2> CSV Table Imports </h2>
+This attempts to import a csv file for the art show. <strong>Please do not refresh this page. THIS PAGE IS FOR EXPERTS ONLY.</strong>
+
+<form action="import_model" method="post" enctype="multipart/form-data">
+    <input type="file" name="model_import" /><br />
+    <input type="submit" value="Upload" />
+</form>
+<br/>
+{% if attendees %}
+        <div class="control-group"><h4>Imported Data</h4></div>
+    <table class="table table-striped datatable">
+    <thead><tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>Type</th>
+        <th>When</th>
+    </tr></thead>
+{% for attendee in attendees %}
+    <tr>
+        <td id="uuid">
+            {{ attendee.id }}
+        </td>
+        <td id="name">{{ attendee|form_link }}</td>
+        <td id="type">{{ attendee.type }} {{ attendee.badge_type_label }}</td>
+        <td id="when">{{ attendee.when }} {{ attendee.registered }}</td>
+    </tr>
+{% endfor %}
+</table>
+{% endif %}
+
+{% endblock %}

--- a/anthrocon/templates/art_show_admin/artist_check_in_out.html
+++ b/anthrocon/templates/art_show_admin/artist_check_in_out.html
@@ -17,7 +17,7 @@
   </div>
   <div class="card-body">
     <form role="form" method="get" action="artist_check_in_out" id="search_form" class="form-inline">
-      <div class="form-group"><a class="btn btn-outline-secondary" href="form?new_app=True">Add an application</a></div>
+      <div class="form-group"><a class="btn btn-outline-secondary" href="form?new_app=True">Add a new {{ c.ART_SHOW_APP_TERM }}</a></div>
       {% if checkout %}<input type="hidden" name="checkout" value="1" />{% endif %}
       <div class="input-group col-sm-6">
         <input class="focus form-control" id="search_bar" type="text" name="search_text" value="{{ search_text }}" />

--- a/anthrocon/templates/art_show_admin/form.html
+++ b/anthrocon/templates/art_show_admin/form.html
@@ -11,7 +11,7 @@ app, c.PAGE_PATH,
 "index", "Return to App List", True
 ) }}
 
-<h2>Art Show Application Form{% if app.attendee %} for {{ app.attendee|form_link }}{% endif %}</h2>
+<h2>Art Show {{ c.ART_SHOW_APP_TERM|title }} Form{% if app.attendee %} for {{ app.attendee|form_link }}{% endif %}</h2>
 
 {% if c.AT_THE_CON and c.SPIN_TERMINAL_AUTH_KEY %}
   {% include 'registration/spin_terminal_form.html' with context %}
@@ -57,7 +57,7 @@ app, c.PAGE_PATH,
       {% endif %}
 
       <div class="form-group">
-        <label for="status" class="col-sm-3 form-text">Application Status</label>
+        <label for="status" class="col-sm-3 form-text">{{ c.ART_SHOW_APP_TERM|title }} Status</label>
         <div class="col-sm-6">
           <select class="form-select" name="status">
             {{ options(c.ART_SHOW_STATUS_OPTS, app.status) }}
@@ -99,7 +99,7 @@ app, c.PAGE_PATH,
           {% if not app.is_new and (not c.AT_THE_CON or not c.SPIN_TERMINAL_AUTH_KEY) %}
           <div class="clearfix"></div>
             <p class="help-block col-sm-6 col-sm-offset-3">
-              <a href="../art_show_applications/edit?id={{ app.id }}" target="_blank">View this application</a> for the payment button.
+              <a href="../art_show_applications/edit?id={{ app.id }}" target="_blank">View this {{ c.ART_SHOW_APP_TERM }}</a> for the payment button.
             </p>
           {% elif not app.is_new %}
             <a href="paid_with_cash?id={{ app.id }}" class="btn btn-success" type="submit">Paid with Cash</a>
@@ -107,6 +107,18 @@ app, c.PAGE_PATH,
             <button type="button" class="btn btn-success" id="start-payment-button" onClick="startTerminalPayment('{{ app.id }}', '', refreshPage, '../art_show_admin/start_terminal_payment')">Prompt Payment at Terminal</button>
           {% endif %}
         {% endif %}
+      </div>
+
+      <div class="row g-3">
+        <div class="col-12 col-sm-6">
+          <label class="form-text">Artist ID</label>
+          <input type="text" name="artist_id" class="form-control" value="{{ app.artist_id }}">
+        </div>
+        <div class="col-12 col-sm-6">
+          <label class="form-text">Mature Artist ID</label>
+          <input type="text" name="artist_id_ad" class="form-control" value="{{ app.artist_id_ad }}">
+          <p class="form-text">This will be the same as the artist ID unless the artist entered a separate mature banner name.</p>
+        </div>
       </div>
 
       {% include 'art_show_applications/art_show_form.html' %}
@@ -122,9 +134,9 @@ app, c.PAGE_PATH,
           (Base Price: {{ app.base_price|default(app.potential_cost)|format_currency }})
         </span>
         <div class="clearfix"></div>
-        <p class="help-block col-sm-6 col-sm-offset-3">Change this to set an override on the application price, or leave
+        <p class="help-block col-sm-6 col-sm-offset-3">Change this to set an override on the {{ c.ART_SHOW_APP_TERM }} price, or leave
           it blank to use the base price.
-          {% if app.status != c.APPROVED %}<br/>Attendees are only asked to pay once their applications are approved.
+          {% if app.status != c.APPROVED %}<br/>Attendees are only asked to pay once their {{ c.ART_SHOW_APP_TERM }}s are approved.
           {% endif %}</p>
       </div>
       {% endif %}

--- a/anthrocon/templates/art_show_admin/index.html
+++ b/anthrocon/templates/art_show_admin/index.html
@@ -12,11 +12,11 @@
 
 <div class="card">
   <div class="card-header">
-    <h3 class="card-title">Art Show Applications</h3>
+    <h3 class="card-title">Art Show {{ c.ART_SHOW_APP_TERM|title }}s</h3>
   </div>
   <div class="card-body">
     <div class="row g-sm-3 mb-3">
-      <div class="col-6"><a class="btn btn-outline-secondary" href="form?new_app=True">Add an application</a></div>
+      <div class="col-6"><a class="btn btn-outline-secondary" href="form?new_app=True">Add a new {{ c.ART_SHOW_APP_TERM }}</a></div>
       <div class="col-6">
         <div class="row g-sm-3">
           <div class="col-8 text-end col-form-label-sm">Status:</div><div class="col-4" id="status_filter"></div>

--- a/anthrocon/templates/art_show_applications/confirmation.html
+++ b/anthrocon/templates/art_show_applications/confirmation.html
@@ -1,0 +1,30 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Art Show {{ c.ART_SHOW_APP_TERM|title }} Received{% endblock %}
+{% block content %}
+<div class="card">
+  <div class="card-body">
+    <h2>{% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %}You've been added to our waitlist!
+      {% else %}Thanks for applying for the Art Show!{% endif %}</h2>
+
+    <p>We've received your {{ c.ART_SHOW_APP_TERM }} for the {{ c.EVENT_NAME }} Art Show. You applied for {{ app.panels }}
+    panel{{ app.panels|pluralize }} and {{ app.tables }} table{{ app.tables|pluralize }} in our general area,
+    and {{ app.panels_ad }} panel{{ app.panels_ad|pluralize }} and {{ app.tables_ad }} table{{ app.tables_ad|pluralize }}
+    in our mature area.</p>
+
+    {% if c.ART_SHOW_WAITLIST and c.AFTER_ART_SHOW_WAITLIST %}
+    <p>You've been added to our waitlist, and we'll let you know if a spot opens up for you.</p>
+    {% endif %}
+
+    <h3>What Happens Next</h3>
+    <p>You will be emailed a link to <a href="edit?id={{ app.id }}" target="_blank">manage your art show {{ c.ART_SHOW_APP_TERM }}</a>.
+    You may change your {{ c.ART_SHOW_APP_TERM }} up until it is approved, declined, or waitlisted by an admin.</p>
+
+    <p>Once your {{ c.ART_SHOW_APP_TERM }} has been reviewed, you will receive an email letting you know of your {{ c.ART_SHOW_APP_TERM }}'s
+    status.{% if c.ART_SHOW_HAS_FEES %} If your {{ c.ART_SHOW_APP_TERM }} is approved, you will also receive a link to pay for
+    the panel and table space you've requested.{% if app.attendee.badge_status != c.NOT_ATTENDING and app.attendee.paid == c.NOT_PAID %}
+    Your payment will also include your badge for the convention.{% endif %}{% endif %}</p>
+
+    <p>If you have any questions, please email us at <a href="mailto:{{c.ART_SHOW_EMAIL}}">{{ c.ART_SHOW_EMAIL }}</a>.</p>
+  </div>
+</div>
+{% endblock %}

--- a/anthrocon/templates/emails/art_show/import.html
+++ b/anthrocon/templates/emails/art_show/import.html
@@ -12,8 +12,8 @@ Thank you for taking part in the Anthrocon 2024 Art Show. Your reservation is co
     <li>Mature Half-Table: {{ app.tables_ad }}</li>
     <li>Display Name: {{ app.banner_name }}</li>
     <li>Artist Code: {{ app.artist_id }}</li>
-    <li>{% if app.banner_name_ad %}Display Name (Mature): {{ app.banner_name_ad }}{% endif %}</li>
-    <li>{% if app.artist_id_ad %}Artist Code (Mature): {{ app.artist_id_ad }}{% endif %}</li>
+    {% if app.banner_name_ad %}<li>Display Name (Mature): {{ app.banner_name_ad }}</li>{% endif %}
+    {% if app.artist_id_ad %}<li>Artist Code (Mature): {{ app.artist_id_ad }}</li>{% endif %}
 </ul>
 Please contact me immediately if any corrections or updates are necessary, or if you have any questions, by replying to this email.
 </p>

--- a/anthrocon/templates/emails/art_show/import.html
+++ b/anthrocon/templates/emails/art_show/import.html
@@ -1,0 +1,80 @@
+<html>
+<head></head>
+<body>
+<p>Hello {{ app.artist_or_full_name }},</p>
+
+<p>
+Thank you for taking part in the Anthrocon 2024 Art Show. Your reservation is confirmed for the following:
+<ul>
+    <li>General Wall Space: {{ app.panel }}</li>
+    <li>General Half-Table: {{ app.tables }}</li>
+    <li>Mature Wall Space: {{ app.panels_ad }}</li>
+    <li>Mature Half-Table: {{ app.tables_ad }}</li>
+    <li>Display Name: {{ app.banner_name }}</li>
+    <li>Artist Code: {{ app.artist_id }}</li>
+    <li>{% if app.banner_name_ad %}Display Name (Mature): {{ app.banner_name_ad }}{% endif %}</li>
+    <li>{% if app.artist_id_ad %}Artist Code (Mature): {{ app.artist_id_ad }}{% endif %}</li>
+</ul>
+Please contact me immediately if any corrections or updates are necessary, or if you have any questions, by replying to this email.
+</p>
+
+<p>
+    <a href="https://docs.google.com/document/d/1L4GmQYZHgWVeL_BSJTPky8n-zgyJbYC0Yz-v1XJSscc/edit" target="_blank">Please read the general
+    instructions at &lt;https://is.gd/ACArtShowPreparations&gt;</a> about how to prepare your artwork, and what to do at the con.
+</p>
+
+<p>
+    This year, we are excited to introduce a new online system to enter artwork information for the Bid Sheets! (If you are using paper forms 
+    that were mailed to some artists upon request, there's no need also to use the online form, but entering your artwork info online will 
+    save time later on.) If you are attending the con, you will make things easier at check-in if you enter your artwork information in advance. 
+    Agents must make sure their clients have entered the info, or enter it themselves.
+</p>
+
+<p>
+    You may enter your pieces on <a href="{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}" target="_blank">your personalized 
+    reservation page at &lt;{{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}&gt;</a>. We recommend bookmarking this page or 
+    saving this email in case you need to add or change pieces later. You can add a piece by clicking the "Add Piece" button and filling 
+    out its title, what gallery you will display it in, price (if the piece will be for sale), and artwork medium, then clicking "Save."
+</p>
+
+<p>
+    Each piece you've saved will be shown in a list, along with the information you filled in. You can edit a piece by clicking the blue 
+    pencil icon next to the piece data, or you can delete a piece by clicking the red "x" icon instead.
+</p>
+
+<p>
+    Once you believe you're done filling out piece information, click "Confirm Current Pieces." This will send us an email letting us know 
+    that your Bid Sheets are ready to print, and send you a list of your pieces to use as reference when preparing your artwork piece labels. 
+    Doing this <strong>does not lock your piece information</strong> - you can edit your pieces up until you check in with us at the con, at 
+    which time we'll give you the printed bid sheets to attach to your artwork. Just please re-confirm your pieces once you believe you are 
+    done editing them.
+</p>
+
+<p>If you have any questions about the system or encounter any errors, please let me know by replying to this email.</p>
+
+<p>
+    We have a crew of dedicated volunteers who are eager to put on a good Art Show, but we can always use more help. If you've already agreed 
+    to volunteer, thank you! Otherwise, if you can spare an hour or two at the con, please volunteer. If you work 18 hours or more, we will 
+    give you a free membership for next year. (Hours worked during setup and teardown count extra toward the total.)
+</p>
+
+<p>
+    Don't forget, we will award ribbons for the best works as judged by Anthrocon's chairman and staff and the Art Show Director, as well as 
+    selected by popular vote. And, among the many events at the con, the Art Show will be hosting a festive Artists and Dealers Reception on 
+    Friday night, July 5. This is your chance to meet and socialize with fellow artists, and invited dealers, sponsors and staff. Feel free 
+    to "dress up" if you can, or even wear a mask or costume! When you check in at the Art Show, you will receive an invitation to the 
+    reception, so I hope to see you there.
+</p>
+
+<p>
+    Safe travels,
+    <br/><br/>&nbsp;&nbsp;PeterCat
+</p>
+
+<p>
+    --
+<br/>PeterCat &lt;artshow@anthrocon.org&gt;&nbsp;&nbsp;&nbsp;Anthrocon Art Show Director
+307-ARTYFUR (+1 307 278 9387)&nbsp;&nbsp;&nbsp;https://www.anthrocon.org/artshow
+</p>
+</body>
+</html>


### PR DESCRIPTION
Adds a way to mass import art show applications, which creates attendees and their art show apps. Also adds a way to update previously imported apps using the import_id, and adds an email that we'll send out to artists introducing them to their application form.