### PR TITLE
Update waitlisted.txt for 2026

### DIFF
--- a/anthrocon/templates/emails/art_show/waitlisted.txt
+++ b/anthrocon/templates/emails/art_show/waitlisted.txt
@@ -1,8 +1,8 @@
 Hello {{ app.artist_or_full_name }},
 
-Thank you for submitting a space request for the {{ c.EVENT_NAME }} Art Show. I’m sorry I must inform you that all available space has been claimed by other artists, so your request is being held on the waitlist in case of cancellations. If space becomes available for you, I will notify you via email.
+Thank you for submitting a space request for the {{ c.EVENT_NAME }} Art Show. I regret to inform you that we are not able to accommodate all artists who have requested space, so your request is being held on the waitlist in case of cancellations. If space becomes available for you, I will notify you via email.
 
-Until then, you may view and change your request at {{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}.
+In the meantime, you may view and change your request at {{ c.URL_BASE }}/art_show_applications/edit?id={{ app.id }}.
 
 Thanks,
 	PeterCat


### PR DESCRIPTION
Generalized the language to apply to requests received before the deadline and manually waitlisted (more artists have requested space than we can comfortably handle), as well as requests received after the deadline and automatically waitlisted.